### PR TITLE
windows: ignore file attribute changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Fork of https://github.com/fsnotify/fsnotify
 
 Contains patches for Tilt Dev.
 
+### Notable Changes
+* [macOS] Fix for panic when debugging ([fsnotify/fsnotify#212](https://github.com/fsnotify/fsnotify/issues/212))
+* [Windows] Recursive watch support
+* [Windows] Customizable buffer size
+* [Windows] File attribute changes are ignored
+  * No `Chmod` operations will be detected or returned on Windows because the underlying Windows API does not support
+    distinguishing these from `Write` operations
+  * Some software (likely AV/security) can cause excessive attribute changes resulting in many spurious write events
+    for otherwise unchanged files
+
 ## Original Readme
 
 [![GoDoc](https://godoc.org/github.com/fsnotify/fsnotify?status.svg)](https://godoc.org/github.com/fsnotify/fsnotify) [![Go Report Card](https://goreportcard.com/badge/github.com/fsnotify/fsnotify)](https://goreportcard.com/report/github.com/fsnotify/fsnotify)
@@ -135,4 +145,3 @@ fsnotify requires support from underlying OS to work. The current NFS protocol d
 
 * [notify](https://github.com/rjeczalik/notify)
 * [fsevents](https://github.com/fsnotify/fsevents)
-

--- a/integration_windows_test.go
+++ b/integration_windows_test.go
@@ -1,0 +1,66 @@
+// +build windows
+
+package fsnotify
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAttributeChangesIgnored(t *testing.T) {
+	watcher := newWatcher(t)
+	defer watcher.Close()
+
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	// Create a file before watching directory
+	testFileAlreadyExists := filepath.Join(testDir, "TestFsnotifyEventsExisting.testfile")
+	{
+		var f *os.File
+		f, err := os.OpenFile(testFileAlreadyExists, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("creating test file failed: %s", err)
+		}
+		f.Sync()
+		f.Close()
+	}
+
+	addWatch(t, watcher, testDir)
+
+	// Receive errors on the error channel on a separate goroutine
+	go func() {
+		for err := range watcher.Errors {
+			t.Errorf("error received: %s", err)
+		}
+	}()
+
+	var eventReceived counter
+	go func() {
+		for event := range watcher.Events {
+			if event.Name == filepath.Clean(testFileAlreadyExists) {
+				t.Logf("event received: %s", event)
+				eventReceived.increment()
+			} else {
+				t.Logf("unexpected event received: %s", event)
+			}
+		}
+	}()
+
+	// make the file read-only, which is an attribute change
+	err := os.Chmod(testFileAlreadyExists, 0400)
+	if err != nil {
+		t.Fatalf("Failed to mark file as read-only: %v", err)
+	}
+
+	// We expect this event to be received almost immediately, but let's wait 500 ms to be sure
+	time.Sleep(500 * time.Millisecond)
+	watcher.Close()
+
+	eReceived := eventReceived.value()
+	if eReceived != 0 {
+		t.Fatalf("should not have received any events, received %d after 500 ms", eReceived)
+	}
+}

--- a/windows.go
+++ b/windows.go
@@ -94,11 +94,21 @@ func (w *Watcher) Add(name string) error {
 	}
 
 	// When reporting file notifications, FILE_ACTION_MODIFIED includes changes to file attributes;
-	// so attribute handling is broken for Windows (op.Chmod will NEVER get used in practice)
+	// so attribute handling is broken for Windows (op.Chmod will NEVER get used in practice).
 	//
 	// To prevent events for attribute changes erroneously showing up as file modifications,
 	// FILE_NOTIFY_CHANGE_ATTRIBUTES (sysFSATTRIB) is excluded from the notify filter.
-	// NOTE: This means attribute changes will NOT be reported for Windows.
+	//
+	// This means attribute changes will NOT be detected on Windows, as this has been deemed
+	// better than misreporting them as file modifications.
+	//
+	// For most purposes, especially since there is no execute bit in Windows/NTFS, these events
+	// are uninteresting, but it appears some security/AV/backup software can trigger excessive
+	// attribute changes resulting in lots of events for otherwise unchanged files.
+	//
+	// To accurately get Chmod events, a substantial refactor would be needed to set up two
+	// underlying watchers - one with a FILE_NOTIFY_CHANGE_ATTRIBUTES filter and another with
+	// the remaining filters, so that attribute changes can be reliably detected.
 	//
 	// See also:
 	// 	* ReadDirectoryChangesW flags: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw


### PR DESCRIPTION
Windows allows filtering file events to include changes to file
attributes. However, when reporting the actual event, attribute
changes are included as `FILE_ACTION_MODIFIED` so it's impossible
to distinguish from file writes.

This means the library's `op::Chmod` is never actually populated
on Windows and so attribute changes aren't really usable. Since
the API does not support specifying an event type filter as a
caller, attribute changes on Windows are ignored rather than being
misreported.